### PR TITLE
Add support for Zig compiler version 0.15.1

### DIFF
--- a/src/populate.zig
+++ b/src/populate.zig
@@ -255,7 +255,7 @@ fn PopulateShape(comptime T: type, comptime shape: anytype) type {
                                     val.* = result;
                                 },
                                 .run_time => {
-                                    var result = std.ArrayList(ChildType).init(allocator);
+                                    var result = std.array_list.Managed(ChildType).init(allocator);
                                     errdefer result.deinit();
                                     errdefer {
                                         for (result.items) |item| {

--- a/src/stringify.zig
+++ b/src/stringify.zig
@@ -46,7 +46,7 @@ pub fn writeTree(tree: Tree, options: Options, writer: anytype) !void {
 
 test writeTree {
     var tree: Tree = .{ .children = &.{} };
-    var array = std.ArrayList(u8).init(std.testing.allocator);
+    var array = std.array_list.Managed(u8).init(std.testing.allocator);
     defer array.deinit();
 
     writeTree(tree, .{}, array.writer());


### PR DESCRIPTION
Hi,

I've updated your package to support the Zig compiler version [0.15.1](https://ziglang.org/download/0.15.1/release-notes.html).

I've made two changes:

1. `std.ArrayList` is now called `std.array_list.Managed`
2. `PopulateShape` now sets a larger eval branch quota. This is required due to the call to `std.fmt.comptimePrint`. I've added a comment to `PopulateShape` that explains why.

Cheers
David