### PR TITLE
Parse CDATA sections

### DIFF
--- a/src/parse.zig
+++ b/src/parse.zig
@@ -168,9 +168,20 @@ pub const Tree = struct {
             }
         };
 
+        /// Represents CDATA in an XML document.
+        pub const Cdata = struct {
+            /// The inner contents of the CDATA block verbatim. This includes all surrounding whitespace.
+            contents: []const u8,
+
+            pub fn freeRecursive(self: Cdata, allocator: std.mem.Allocator) void {
+                allocator.free(self.contents);
+            }
+        };
+
         elem: Elem,
         text: Text,
         comment: Comment,
+        cdata: Cdata,
 
         pub fn freeRecursive(self: Node, allocator: std.mem.Allocator) void {
             switch (self) {
@@ -381,6 +392,12 @@ pub fn StateMachine(comptime Builder: type) type {
                     .comment_close => {
                         try self.builder.closeComment();
                     },
+                    .cdata_open => {
+                        try self.builder.addCdata();
+                    },
+                    .cdata_close => {
+                        try self.builder.closeCdata();
+                    },
                     .meta_attribute => {},
                     .meta_attribute_value => {},
                     .doctype => {},
@@ -560,13 +577,31 @@ pub const RuntimeBuilder = struct {
         } });
     }
 
+    pub fn addCdata(self: *RuntimeBuilder) !void {
+        std.debug.assert(self.stack.items.len > 0);
+        const last = &self.stack.items[self.stack.items.len - 1];
+        try last.children.append(.{
+            .cdata = .{ .contents = &.{} },
+        });
+    }
+
+    pub fn closeCdata(self: *RuntimeBuilder) !void {
+        std.debug.assert(self.stack.items.len > 0);
+        const last = &self.stack.items[self.stack.items.len - 1];
+        std.debug.assert(last.children.items.len > 0);
+        std.debug.assert(last.children.items[last.children.items.len - 1] == .cdata);
+        try last.children.append(.{ .text = .{
+            .contents = &.{},
+        } });
+    }
+
     pub fn appendTextChunk(self: *RuntimeBuilder, text_content: []const u8) !void {
         std.debug.assert(self.stack.items.len > 0);
         const last = &self.stack.items[self.stack.items.len - 1];
         if (last.children.items.len > 0) {
             const last_node = &last.children.items[last.children.items.len - 1];
             switch (last_node.*) {
-                inline .text, .comment => |*text_node| {
+                inline .text, .comment, .cdata => |*text_node| {
                     const concat = try self.data_allocator.alloc(u8, text_node.contents.len + text_content.len);
                     @memcpy(concat[0..text_node.contents.len], text_node.contents);
                     @memcpy(concat[text_node.contents.len..], text_content);
@@ -1072,4 +1107,20 @@ test Tree {
 
     try std.testing.expectEqualSlices(u8, "\n    this is a gap!!!    \n    \n    \n    ", text);
     try std.testing.expectEqualSlices(u8, "this is a gap!!!", text2);
+}
+
+test "parsing CDATA" {
+    const payload =
+        \\<item>
+        \\  <title>Title #1</title>
+        \\  <data><![CDATA[<a>foobar]]<br/>]]></data>
+        \\</item>
+    ;
+
+    const result = try fromSlice(std.testing.allocator, payload);
+    defer result.deinit();
+
+    const item_tag = result.tree.elementByTagName("item").?;
+    const data_tag = item_tag.tree.?.elementByTagName("data").?;
+    try std.testing.expectEqualStrings("<a>foobar]]<br/>", data_tag.tree.?.children[0].cdata.contents);
 }

--- a/src/populate.zig
+++ b/src/populate.zig
@@ -316,31 +316,6 @@ fn PopulateShape(comptime T: type, comptime shape: anytype) type {
                                 elem.attributes,
                                 val,
                             );
-                        } else if (struct_info.fields.len == 2 and shape[0] == .cdata) {
-                            const tag_name = shape[1];
-
-                            const elem: Tree.Node.Elem = for (tree.children) |child| {
-                                switch (child) {
-                                    .elem => |elem_child| {
-                                        if (std.mem.eql(u8, elem_child.tag_name, tag_name)) {
-                                            break elem_child;
-                                        }
-                                    },
-                                    else => {},
-                                }
-                            } else return ContentError.MissingChild;
-
-                            const cdata_child = for (elem.tree.?.children) |child| {
-                                switch (child) {
-                                    .cdata => |cdata_child| break cdata_child,
-                                    else => {},
-                                }
-                            } else return ContentError.MissingCdata;
-
-                            val.* = switch (mode) {
-                                .compile_time => cdata_child.contents,
-                                .run_time => try allocator.dupe(u8, cdata_child.contents),
-                            };
                         } else if (struct_info.fields.len > 2 and shape[0] == .one_of) {
                             if (dest_type_info != .@"union") {
                                 @compileError(cannot_be_applied ++ ", must be a union type");
@@ -455,6 +430,18 @@ fn PopulateShape(comptime T: type, comptime shape: anytype) type {
                                 };
                             },
                         }
+                    } else if (shape == .cdata) {
+                        const cdata_child: Tree.Node.Cdata = for (tree.children) |child| {
+                            switch (child) {
+                                .cdata => |cdata_child| break cdata_child,
+                                else => {},
+                            }
+                        } else return ContentError.MissingCdata;
+
+                        val.* = switch (mode) {
+                            .compile_time => cdata_child.contents,
+                            .run_time => try allocator.dupe(u8, cdata_child.contents),
+                        };
                     }
                 },
                 else => @compileError("Unknown shape type " ++ shape_print),
@@ -780,32 +767,41 @@ test "Populate: missing option" {
     try std.testing.expectError(ContentError.MissingOption, Populate(OptionDocument).initFromSlice(std.testing.allocator, test_missing_option));
 }
 
-test "Populate: with CDATA" {
-    const test_payload =
-        \\<item>
-        \\  <title>Title #1</title>
-        \\  <data><![CDATA[<a>foobar<br/>]]></data>
-        \\</item>
-    ;
+const test_cdata_payload =
+    \\<item>
+    \\  <title>Title #1</title>
+    \\  <data><![CDATA[<a>foobar<br/>]]></data>
+    \\</item>
+;
 
-    const CdataDocument = struct {
-        pub const Item = struct {
-            pub const xml_shape = .{
-                .text = .{ .cdata, "data" },
-            };
-
-            text: []const u8,
-        };
-
+const CdataDocument = struct {
+    pub const Item = struct {
         pub const xml_shape = .{
-            .item = .{ .element, "item", Item },
+            .text = .{ .element, "data", .cdata },
         };
 
-        item: Item,
+        text: []const u8,
     };
 
-    const document = try Populate(CdataDocument).initFromSlice(std.testing.allocator, test_payload);
+    pub const xml_shape = .{
+        .item = .{ .element, "item", Item },
+    };
+
+    item: Item,
+};
+
+test "Populate: with CDATA" {
+
+    const document = try Populate(CdataDocument).initFromSlice(std.testing.allocator, test_cdata_payload);
     defer document.deinit();
 
     try std.testing.expectEqualStrings("<a>foobar<br/>", document.value.item.text);
+}
+
+test "Populate: comptime with CDATA" {
+    @setEvalBranchQuota(8192);
+    const tree = try parse.fromSliceComptime(test_cdata_payload);
+    const document: CdataDocument = try comptime Populate(CdataDocument).initFromTreeComptime(tree);
+
+    try std.testing.expectEqualStrings("<a>foobar<br/>", document.item.text);
 }


### PR DESCRIPTION
I'm quite new to Zig and was trying to parse an RSS feed and ran into an issue where one source was using CDATA sections for their item descriptions so I tried out adding support for parsing them into strings.

I tried to follow along with how things were done in other places, let me know if anything looks weird that you'd like me to change.

I worked on this using the `0.15.2` branch since that's what I had installed, but let me know if you want me to rebase this against `master` instead and figure that out to check that the test pass on there as well.

Thanks for making the package, I really enjoy it (especially the `Populate` parsing). 👏🏽 